### PR TITLE
Added support for Apple Touch icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gitbook-plugin-custom-favicon
 Add your own favicon to gitbook themes.
 
-Plugin deletes the gitbook favicon located at `"_book/gitbook/images/favicon.ico"` and replaces with your favicon.
+Plugin deletes the gitbook favicon located at `"_book/gitbook/images/favicon.ico"` and `"_book/gitbook/images/apple-touch-icon-precomposed-152.png"` and replaces them with your favicons.
 
 There is probably a better way to do this, but this at least works for _most_ use cases.  However, this is a hack :smiley:
 
@@ -11,13 +11,15 @@ There is probably a better way to do this, but this at least works for _most_ us
 
 * Add `custom-favicon` to your `plugins` array
 * Add path to your favicon in `favicon` under `pluginsConfig`
+* Add path to your iOS favicon (152x152px .png image) in `iosFavicon` under `pluginsConfig`
 
 #### book.json
 ```json
 {
 	"plugins" : ["custom-favicon"],
 	"pluginsConfig" : {
-		"favicon": "path/to/favicon.ico"
+		"favicon": "path/to/favicon.ico",
+		"iosFavicon": "path/to/iosFavicon.png"
 	}
 }
 ```

--- a/index.js
+++ b/index.js
@@ -7,12 +7,21 @@ module.exports = {
 	hooks: {
 
 		"finish" : function () {
+			// favicon.ico - pluginsConfig.favicon setting
 			var pathFile = this.options.pluginsConfig && this.options.pluginsConfig.favicon;
 			var favicon = path.join(process.cwd(), pathFile);
 			var gitbookFaviconPath = path.join(process.cwd(), '_book', 'gitbook', 'images', 'favicon.ico');
 			if (pathFile && fs.existsSync(pathFile) && fs.existsSync(gitbookFaviconPath)){
 				fs.unlinkSync(gitbookFaviconPath);
 				fs.createReadStream(favicon).pipe(fs.createWriteStream(gitbookFaviconPath));
+			}
+			// apple-touch-icon-precomposed-152.png - pluginsConfig.iosFavicon setting
+			var iosPathFile = this.options.pluginsConfig && this.options.pluginsConfig.iosFavicon;
+			var iosFavicon = path.join(process.cwd(), iosPathFile);
+			var gitbookIosFaviconPath = path.join(process.cwd(), '_book', 'gitbook', 'images', 'apple-touch-icon-precomposed-152.png');
+			if (iosPathFile && fs.existsSync(iosPathFile) && fs.existsSync(gitbookIosFaviconPath)){
+				fs.unlinkSync(gitbookIosFaviconPath);
+				fs.createReadStream(iosFavicon).pipe(fs.createWriteStream(gitbookIosFaviconPath));
 			}
 		}
 	},

--- a/package.json
+++ b/package.json
@@ -15,6 +15,23 @@
     "url": "https://github.com/dtolb/gitbook-plugin-custom-favicon"
   },
   "author": "Dan Tolbert",
+  "contributors": [
+    "Luca Nardi"
+  ],
   "license": "MIT",
-  "dependencies": {}
+  "dependencies": {},
+  "gitbook": {
+    "properties": {
+      "favicon": {
+        "type": "string",
+        "default": null,
+        "description": "path of custom favicon.ico"
+      },
+      "iosFavicon": {
+        "type": "string",
+        "default": null,
+        "description": "path of custom apple-touch-icon-precomposed-152.png"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Gitbook supports a `apple-touch-icon-precomposed-152.png` in addition to `favicon.ico`.
This fork allows to specify a custom icon for both.